### PR TITLE
Exclude .spec and .test Files in codeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+exclude_patterns:
+- "**/*.spec.js"
+- "**/*.test.js"
+- "e2e-tests/"
+- "jestConfig/"
+- "webpackConfig/"
+
+


### PR DESCRIPTION
#### What does this PR do?
- Exclude test and configuration files from codeClimate analysis

#### Description of Task proposed in this pull request?
- Exludes files with the following  extensions and folders: 
  "**/*.spec.js"
  "**/*.test.js"
  "e2e-tests/"
  "jestConfig/"
 "webpackConfig/"

#### How should this be manually tested (Quality Assurance)?
- Confirm that the stated files are excluded from codeClimate analysis by checking this branch analysis

#### What are the relevant pivotal tracker stories?
- None

#### What I have learned working on this feature:
- Codeclimate advanced configuration

#### Screenshots:
- None







